### PR TITLE
Reverted progress bar (bad air is smaller bar), raised the max value to 768, commented about the lib used for LCD, change lcd.begin to lcd.init

### DIFF
--- a/2_Software/Arduino/main/I2C_Chars.ino
+++ b/2_Software/Arduino/main/I2C_Chars.ino
@@ -58,7 +58,7 @@ byte p5[8] = {
 };
 
 void Setup_I2C() {
-  lcd.begin();
+  lcd.init();
   // i2c-Display intialisieren
   lcd.createChar(0, p1);
   lcd.createChar(1, p2);
@@ -72,10 +72,10 @@ void Setup_I2C() {
   else lcd.noBacklight(); 
 }
 
-void LCD_Draw() {
+void LCD_Draw(int value) {
   lcd.setCursor(0, 1);
 
-  double a = lenght / 100 * percent;
+  double a = lenght / 100 * value;
 
   // drawing black rectangles on LCD
 


### PR DESCRIPTION
Der Fortschrittsbalken zeigt nun den Wert an, der auch als Prozent angegeben wird, also die schlechte Luft. Ein kurzer Balken ist schlechte Luft, ein langer ist gute.
Ich hatte Probleme die LCD-Bibliothek zu finden. Deshalb habe ich die Bibliothek genutzt, die bei der Arduino IDE im Bibliotheksverwalter installierbar ist. Den Namen habe ich kommentiert. Diese Bibliothek unterstützt kein lcd.begin. Daher habe ich es in lcd.init geändert.
Der Maximalwert von 512 hat bei meinem Sensor dazu geführt, dass immer schlechte Luft war. Selbst wenn ich ihn nach draußen in die frische Luft gestellt habe. Daher habe ich den Wert auf 768 erhöht. So passt es, zumindest für mich.
Ich hatte versucht auf die MQ-135 Bibliothek umzusteigen. Das verbrauchte aber zu viel Speicher. Deshalb habe ich den Code wieder entfernt.